### PR TITLE
Forward `options` key from `ZarrMultivecDataFetcherClass` constructor to allow configuring `FetchStore` instance

### DIFF
--- a/src/ZarrMultivecDataFetcher.js
+++ b/src/ZarrMultivecDataFetcher.js
@@ -62,7 +62,7 @@ const ZarrMultivecDataFetcher = function ZarrMultivecDataFetcher(HGC, ...args) {
             if (dataConfig.url) {
               // console.assert(dataConfig.url.endsWith('.zarr'));
               // S3 bucket must have a CORS policy to allow reading from any origin.
-              const { url, options } = dataConfig;
+              const { url, options = {} } = dataConfig;
               this.store = new FetchStore(url, options);
               this.storeRoot = Promise.resolve(zarrRoot(this.store));
             }

--- a/src/ZarrMultivecDataFetcher.js
+++ b/src/ZarrMultivecDataFetcher.js
@@ -62,7 +62,8 @@ const ZarrMultivecDataFetcher = function ZarrMultivecDataFetcher(HGC, ...args) {
             if (dataConfig.url) {
               // console.assert(dataConfig.url.endsWith('.zarr'));
               // S3 bucket must have a CORS policy to allow reading from any origin.
-              this.store = new FetchStore(dataConfig.url);
+              const { url, options } = dataConfig;
+              this.store = new FetchStore(url, options);
               this.storeRoot = Promise.resolve(zarrRoot(this.store));
             }
 


### PR DESCRIPTION
Missed these changes in my last PR (#3)